### PR TITLE
fix: stop re-showing new-quest notification on every store change

### DIFF
--- a/AutoQuestComplete.plugin.js
+++ b/AutoQuestComplete.plugin.js
@@ -75,6 +75,8 @@ class AutoQuestComplete {
         this._activeQuestId = null;
         this._activeQuestName = null;
         this._unsupportedQuests = new Set();
+        this._notifiedQuests = new Set();
+        this._snoozeTimers = new Map();
         this.settings;
 
         try {
@@ -136,7 +138,13 @@ class AutoQuestComplete {
     stop() {
         if (this._questsStore && this._questsStore.removeChangeListener) {
             this._questsStore.removeChangeListener(this._boundHandleQuestChange);
+            this._questsStore.removeChangeListener(this._boundNewQuestHandler);
         }
+        for (const timer of this._snoozeTimers.values()) {
+            clearTimeout(timer);
+        }
+        this._snoozeTimers.clear();
+        this._notifiedQuests.clear();
         this._unsupportedQuests.clear();
     }
 
@@ -169,7 +177,26 @@ class AutoQuestComplete {
             new Date(x.config.expiresAt).getTime() > Date.now()
         );
 
-        if (new_quest && quest && new_quest !== quest && this.settings.enableNotify) {
+        // Clean up notified IDs for quests that are no longer "new" (accepted, completed or expired)
+        for (const id of this._notifiedQuests) {
+            const stillPending = [...this._questsStore.quests.values()].some(x =>
+                x.id === id &&
+                !x.userStatus?.enrolledAt &&
+                !x.userStatus?.completedAt &&
+                new Date(x.config.expiresAt).getTime() > Date.now()
+            );
+            if (!stillPending) {
+                this._notifiedQuests.delete(id);
+                const timer = this._snoozeTimers.get(id);
+                if (timer) {
+                    clearTimeout(timer);
+                    this._snoozeTimers.delete(id);
+                }
+            }
+        }
+
+        if (new_quest && quest && new_quest !== quest && this.settings.enableNotify && !this._notifiedQuests.has(new_quest.id)) {
+            this._notifiedQuests.add(new_quest.id);
             // UI.showNotice("New quest available! Please accept it to start auto completing.", {
             //     type: "info",
             //     timeout: 5 * 60 * 1000,
@@ -261,9 +288,13 @@ class AutoQuestComplete {
                 {
                     label: "Remind Me Later",
                     onClick: () => {
-                        setTimeout(() => {
+                        const existing = this._snoozeTimers.get(quest.id);
+                        if (existing) clearTimeout(existing);
+                        const timer = setTimeout(() => {
+                            this._snoozeTimers.delete(quest.id);
                             this.showQuestNotification(quest, true);
                         }, 60 * 60 * 1000);
+                        this._snoozeTimers.set(quest.id, timer);
                     }
                 }
             ]


### PR DESCRIPTION
## Summary
- `handleNewQuest` is registered as a `QuestStore` change listener, so it fires on every store change. With no dedupe, the new-quest notification kept re-appearing even after the user pressed **Remind Me Later** or dismissed it.
- Added a `_notifiedQuests` Set so each pending quest is only notified once, and a `_snoozeTimers` Map so **Remind Me Later** timers are tracked and can be cancelled.
- `stop()` was only removing one of the two change listeners added in `start()` and was leaving snooze timers behind — now it removes both listeners and clears timers + sets on unload.

## Behaviour after the fix
- Notification appears once per new pending quest.
- Dismissing it or pressing **Go to Quests** does not cause it to come back on the next store tick.
- **Remind Me Later** shows the reminder exactly once, 1h later, and is cancelled cleanly if the plugin is disabled before it fires.
- Entries are cleaned up automatically when a quest is accepted, completed or expires, so future new quests notify normally.

## Test plan
- [ ] Load the plugin with a pending (not-enrolled) quest available alongside an active one — verify the notification appears exactly once.
- [ ] Dismiss the notification and trigger store changes (e.g. open/close quest pages) — verify it does not reappear.
- [ ] Press **Remind Me Later**, wait ~1h (or temporarily shorten the timeout for testing) — verify reminder fires once.
- [ ] Disable the plugin while a snooze timer is pending — verify no notification fires afterwards.
- [ ] Accept the pending quest — verify a later new quest still produces a notification.